### PR TITLE
Adding Try Catch blocks to catch e.g. "TypeError: fullscreen error"

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export default function FullScreen({ isEnter, onChange = (e) => e, children }) {
         try {
           onChange(screenfull.isFullscreen);
         } catch (e) {
-          console.debug("Catching Fullscreen error for request or exit to prevent TypeError: fullscreen error");
+          console.debug("Catching Fullscreen error for change to prevent TypeError: fullscreen error");
           console.error(e); //e.g. "TypeError: fullscreen error"
         }
       };

--- a/index.js
+++ b/index.js
@@ -6,10 +6,15 @@ export default function FullScreen({ isEnter, onChange = (e) => e, children }) {
 
   useEffect(() => {
     if (domNode && screenfull.isEnabled) {
-      if (isEnter) {
-        screenfull.request(domNode);
-      } else {
-        screenfull.exit();
+      try {
+        if (isEnter) {
+          screenfull.request(domNode);
+        } else {
+          screenfull.exit();
+        }
+      } catch (e) {
+        console.debug("Catching Fullscreen error for request or exit to prevent TypeError: fullscreen error");
+        console.error(e); //e.g. "TypeError: fullscreen error"
       }
     }
   }, [isEnter, domNode]);
@@ -17,7 +22,12 @@ export default function FullScreen({ isEnter, onChange = (e) => e, children }) {
   useEffect(() => {
     if (screenfull.isEnabled) {
       const cb = () => {
-        onChange(screenfull.isFullscreen);
+        try {
+          onChange(screenfull.isFullscreen);
+        } catch (e) {
+          console.debug("Catching Fullscreen error for request or exit to prevent TypeError: fullscreen error");
+          console.error(e); //e.g. "TypeError: fullscreen error"
+        }
       };
 
       screenfull.on("change", cb);


### PR DESCRIPTION
I simulated the situation by adding a line `throw new TypeError("fullscreen error")` to screenfull.js and saw my console logs